### PR TITLE
Addition of services to move the arm's joints without planning

### DIFF
--- a/frida_manipulation_interfaces/CMakeLists.txt
+++ b/frida_manipulation_interfaces/CMakeLists.txt
@@ -17,6 +17,8 @@ find_package(catkin REQUIRED COMPONENTS
 add_service_files(
   FILES
   Gripper.srv
+  MoveJointSDK.srv
+  MoveVeloJointSDK.srv
 #  EnableOctomap.srv
 )
 

--- a/frida_manipulation_interfaces/srv/MoveJointSDK.srv
+++ b/frida_manipulation_interfaces/srv/MoveJointSDK.srv
@@ -1,0 +1,6 @@
+int64 joint_number
+float32 degree
+float32 vel
+float32 acc
+---
+bool success

--- a/frida_manipulation_interfaces/srv/MoveVeloJointSDK.srv
+++ b/frida_manipulation_interfaces/srv/MoveVeloJointSDK.srv
@@ -1,0 +1,4 @@
+int64 joint_number
+float32 speed
+---
+bool success


### PR DESCRIPTION
These services function as a simple and quick way to move the XArm joints since it doesnt require any planning, and most of the control is made through the XArm embedded controller